### PR TITLE
RED-282: 'Wallet already staked...' error message is not displayed

### DIFF
--- a/components/molecules/StakeDisplay.tsx
+++ b/components/molecules/StakeDisplay.tsx
@@ -157,19 +157,19 @@ export const StakeDisplay = () => {
                         (stakeInfo?.nominee &&
                           stakeInfo.nominee !== nodeStatus?.nomineeAddress)
                         ? "text-gray-400 border border-bodyFg tooltip tooltip-bottom"
-                          : "bg-primary text-white"
+                        : "bg-primary text-white"
                       }
                     `}
-                    disabled={
+                    disabled={!!(
                       hasNodeStopped ||
                       !nodeStatus?.nomineeAddress ||
                       (stakeInfo?.nominee &&
                         stakeInfo.nominee !== nodeStatus?.nomineeAddress)
-                    }
+                    )}
                     data-tip={
                       stakeInfo?.nominee &&
                       stakeInfo.nominee !== nodeStatus?.nomineeAddress
-                        ? "Stake Address is staked to another node. Use force remove in settings to remove existing stake in order to stake to this node."
+                        ? "Wallet is staked to another node. Navigate to settings (top-right cog icon) to force remove stake."
                         : hasNodeStopped || !nodeStatus?.nomineeAddress
                         ? "Node is stopped or nominee address is missing"
                         : ""

--- a/components/molecules/StakeDisplay.tsx
+++ b/components/molecules/StakeDisplay.tsx
@@ -169,7 +169,7 @@ export const StakeDisplay = () => {
                     data-tip={
                       stakeInfo?.nominee &&
                       stakeInfo.nominee !== nodeStatus?.nomineeAddress
-                        ? "Wallet is staked to another node. Navigate to settings (top-right cog icon) to force remove stake."
+                        ? "Connected wallet is staked to another node. Navigate to settings to force remove stake if you wish to stake this current node."
                         : hasNodeStopped || !nodeStatus?.nomineeAddress
                         ? "Node is stopped or nominee address is missing"
                         : ""

--- a/components/molecules/StakeDisplay.tsx
+++ b/components/molecules/StakeDisplay.tsx
@@ -11,6 +11,7 @@ import { ClipboardIcon } from "../atoms/ClipboardIcon";
 import { MobileModalWrapper } from "../layouts/MobileModalWrapper";
 import { useAccountStakeInfo } from "../../hooks/useAccountStakeInfo";
 import { useSettings } from "../../hooks/useSettings";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 
 export const StakeDisplay = () => {
   const addressRef = useRef<HTMLSpanElement>(null);
@@ -147,13 +148,32 @@ export const StakeDisplay = () => {
                     Remove Stake
                   </button>
                   <button
-                    className={
-                      "px-3 py-2 rounded text-sm basis-0 grow max-w-[12rem] " +
-                      (hasNodeStopped || !nodeStatus?.nomineeAddress
-                        ? "text-gray-400 border border-bodyFg"
-                        : "bg-primary text-white")
+                    className={`
+                      px-3 py-2 rounded text-sm basis-0 grow max-w-[12rem] 
+                      flex items-center justify-center gap-2
+                      ${
+                        hasNodeStopped ||
+                        !nodeStatus?.nomineeAddress ||
+                        (stakeInfo?.nominee &&
+                          stakeInfo.nominee !== nodeStatus?.nomineeAddress)
+                        ? "text-gray-400 border border-bodyFg tooltip tooltip-bottom"
+                          : "bg-primary text-white"
+                      }
+                    `}
+                    disabled={
+                      hasNodeStopped ||
+                      !nodeStatus?.nomineeAddress ||
+                      (stakeInfo?.nominee &&
+                        stakeInfo.nominee !== nodeStatus?.nomineeAddress)
                     }
-                    disabled={hasNodeStopped || !nodeStatus?.nomineeAddress}
+                    data-tip={
+                      stakeInfo?.nominee &&
+                      stakeInfo.nominee !== nodeStatus?.nomineeAddress
+                        ? "Stake Address is staked to another node. Use force remove in settings to remove existing stake in order to stake to this node."
+                        : hasNodeStopped || !nodeStatus?.nomineeAddress
+                        ? "Node is stopped or nominee address is missing"
+                        : ""
+                    }
                     onClick={() => {
                       resetModal();
                       setContent(
@@ -167,6 +187,10 @@ export const StakeDisplay = () => {
                       setShowModal(true);
                     }}
                   >
+                    {stakeInfo?.nominee &&
+                      stakeInfo.nominee !== nodeStatus?.nomineeAddress && (
+                        <ExclamationTriangleIcon className="h-5 w-5 text-yellow-500" />
+                      )}
                     Add Stake
                   </button>
                 </div>

--- a/pages/onboarding/index.tsx
+++ b/pages/onboarding/index.tsx
@@ -608,7 +608,7 @@ const Onboarding = () => {
                                   stakeInfo?.nominee &&
                                   stakeInfo.nominee !==
                                     nodeStatus?.nomineeAddress
-                                    ? "Wallet is staked to another node. Press `Skip setup for now` to continue. Then use settings (top-right cog) to remove existing stake."
+                                    ? "Connected wallet is staked to another node. Press `Skip setup for now` to continue. Navigate to settings to force remove existing stake if you wish to stake this current node."
                                     : isEmpty ||
                                       stakedAmount < minimumStakeRequirement
                                     ? "Please enter a valid stake amount"

--- a/pages/onboarding/index.tsx
+++ b/pages/onboarding/index.tsx
@@ -608,7 +608,7 @@ const Onboarding = () => {
                                   stakeInfo?.nominee &&
                                   stakeInfo.nominee !==
                                     nodeStatus?.nomineeAddress
-                                    ? "Wallet is staked to another node. Press `Skip setup for now` to continue. Skip setup, then use settings (top-right cog) to remove existing stake."
+                                    ? "Wallet is staked to another node. Press `Skip setup for now` to continue. Then use settings (top-right cog) to remove existing stake."
                                     : isEmpty ||
                                       stakedAmount < minimumStakeRequirement
                                     ? "Please enter a valid stake amount"

--- a/pages/onboarding/index.tsx
+++ b/pages/onboarding/index.tsx
@@ -8,6 +8,7 @@ import {
   QuestionMarkCircleIcon,
 } from "@heroicons/react/24/solid";
 import { ArrowUpRightIcon } from "@heroicons/react/20/solid";
+import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { Logo } from "../../components/atoms/Logo";
 import { useAccount, useNetwork, useSwitchNetwork, useDisconnect } from "wagmi";
 import { useNodeStatus } from "../../hooks/useNodeStatus";
@@ -26,6 +27,7 @@ import {
   NotificationSeverity,
   NotificationType,
 } from "../../hooks/useNotificationsStore";
+import { useAccountStakeInfo } from "../../hooks/useAccountStakeInfo";
 
 const tokensClaimedByKey = "tokensClaimedBy";
 export const onboardingCompletedKey = "onboardingCompleted";
@@ -57,6 +59,7 @@ const Onboarding = () => {
       setAccountBalance("");
     },
   });
+  const { stakeInfo } = useAccountStakeInfo(address);
   const [isStakingComplete, setIsStakingComplete] = useState(
     localStorage.getItem(onboardingCompletedKey) === "true"
   );
@@ -593,18 +596,46 @@ const Onboarding = () => {
                                   await sendTransaction();
                                 }}
                                 disabled={
-                                  isEmpty ||
-                                  stakedAmount < minimumStakeRequirement
+                                  !!(
+                                    isEmpty ||
+                                    stakedAmount < minimumStakeRequirement ||
+                                    (stakeInfo?.nominee &&
+                                      stakeInfo.nominee !==
+                                        nodeStatus?.nomineeAddress)
+                                  )
                                 }
-                                className={
-                                  (isEmpty ||
-                                  stakedAmount < minimumStakeRequirement
-                                    ? "bg-gray-300"
-                                    : "bg-indigo-600 hover:bg-indigo-700") +
-                                  " text-white text-sm font-semibold w-32 py-2 rounded flex justify-center ease-in-out duration-300 " +
-                                  GeistSans.className
+                                data-tip={
+                                  stakeInfo?.nominee &&
+                                  stakeInfo.nominee !==
+                                    nodeStatus?.nomineeAddress
+                                    ? "Wallet is staked to another node. Press `Skip setup for now` to continue. Skip setup, then use settings (top-right cog) to remove existing stake."
+                                    : isEmpty ||
+                                      stakedAmount < minimumStakeRequirement
+                                    ? "Please enter a valid stake amount"
+                                    : ""
                                 }
+                                className={`
+                                  text-white text-sm font-semibold w-32 py-2 rounded
+                                  flex items-center justify-center gap-2
+                                  ease-in-out duration-300 ${
+                                    GeistSans.className
+                                  }
+                                  ${
+                                    isEmpty ||
+                                    stakedAmount < minimumStakeRequirement ||
+                                    (stakeInfo?.nominee &&
+                                      stakeInfo.nominee !==
+                                        nodeStatus?.nomineeAddress)
+                                      ? "bg-gray-300 tooltip tooltip-bottom"
+                                      : "bg-indigo-600 hover:bg-indigo-700"
+                                  }
+                              `}
                               >
+                                {stakeInfo?.nominee &&
+                                  stakeInfo.nominee !==
+                                    nodeStatus?.nomineeAddress && (
+                                    <ExclamationTriangleIcon className="h-5 w-5 text-yellow-500" />
+                                  )}
                                 Stake
                               </button>
                             )}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f959bba0-be78-4f26-a510-921c89146aad)
![image](https://github.com/user-attachments/assets/fd2961fb-0360-466a-bb70-9603173959e1)

https://linear.app/shm/issue/RED-282/[new-validator-design]-wallet-already-staked-error-message-is-not

Summary: Enhanced "Add Stake" button in StakeDisplay and Onboarding component:

- Added visual warning and disable button when EOA wallet nominee and current nominee node mismatch

- Implemented conditional tooltips when button disabled