### PR TITLE
RED-294: Migrate validator-gui repos to node 18.19.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@types/express": "4.17.17",
         "@types/js-yaml": "4.0.5",
         "@types/jsonwebtoken": "9.0.2",
-        "@types/node": "18.16.1",
+        "@types/node": "18.19.1",
         "@types/react": "18.2.15",
         "@types/react-dom": "18.2.7",
         "@typescript-eslint/eslint-plugin": "5.62.0",
@@ -1929,9 +1929,12 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.16.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.1.tgz",
-      "integrity": "sha512-DZxSZWXxFfOlx7k7Rv4LAyiMroaxa3Ly/7OOzZO8cBNho0YzAi4qlbrx8W27JGqG57IgR/6J7r+nOJWw6kcvZA=="
+      "version": "18.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.1.tgz",
+      "integrity": "sha512-mZJ9V11gG5Vp0Ox2oERpeFDl+JvCwK24PGy76vVY/UgBtjwJWc5rYBThFxmbnYOm9UPZNm6wEl/sxHt2SU7x9A==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -10602,6 +10605,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/express": "4.17.17",
     "@types/js-yaml": "4.0.5",
     "@types/jsonwebtoken": "9.0.2",
-    "@types/node": "18.16.1",
+    "@types/node": "18.19.1",
     "@types/react": "18.2.15",
     "@types/react-dom": "18.2.7",
     "@typescript-eslint/eslint-plugin": "5.62.0",


### PR DESCRIPTION
https://linear.app/shm/issue/RED-294/migrate-validator-repos-to-node-18191 

Update @types/node to version 18.19.1.Tested with local network.

- `npm` package not present to update