### PR TITLE
BLUE-264: Metamask icon rendering fix

### DIFF
--- a/pages/onboarding/index.tsx
+++ b/pages/onboarding/index.tsx
@@ -715,10 +715,6 @@ Onboarding.getLayout = function getLayout(page: ReactElement) {
           name="description"
           content="Dashboard to configure a Shardeum validator"
         />
-        <meta
-          httpEquiv="Content-Security-Policy"
-          content="default-src 'self'; connect-src 'self' https://atomium.shardeum.org/; upgrade-insecure-requests"
-        />
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
### Summary
This PR removes the **`<meta>`** tag with the Content Security Policies as they're better defined in the **[security-headers.ts](https://github.com/shardeum/validator-gui/blob/dev/api/security-headers.ts#L7-L21)** on the server side.

### **[Linear Task](https://linear.app/shm/issue/BLUE-264/validator-setup-metamask-icon-is-not-displayed-a-blank-image-appears)**