### PR TITLE
RED-302: Set Password Command Fails to Change Password Despite Valid Input

### DIFF
--- a/api/handlers/node.ts
+++ b/api/handlers/node.ts
@@ -174,7 +174,7 @@ export default function configureNodeHandlers(apiRouter: Router) {
         return;
       }
 
-      execFileSync('operator-cli', ['gui', 'set', 'password', '-h', req.body.newPassword]);
+      execFileSync('operator-cli', ['gui', 'set', 'password', '-h'], { input: req.body.newPassword });
       res.status(200).json({ status: "ok" })
     }));
 


### PR DESCRIPTION
https://linear.app/shm/issue/RED-302/[new-validator-gui]-set-password-command-fails-to-change-password

Summary: update CLI password set command, using the new CLI method that accepts the password via stdin instead of as a command-line argument (was done in CLI to avoid shell misinterpretation with special characters (i.e. $)