### PR TITLE
Red 318: Stake info throws repeated error if connected wallet has no activity on the network

### DIFF
--- a/api/handlers/node.ts
+++ b/api/handlers/node.ts
@@ -128,20 +128,8 @@ export default function configureNodeHandlers(apiRouter: Router) {
         badRequestResponse(res, 'No address provided');
         return;
       }
-  
-
       console.log('Executing operator-cli stake_info...');
       const output = execFileSync('operator-cli', ['stake_info', address], { encoding: 'utf8' })
-
-      // Check for specific error message 
-      // Case where query was valid but no stake info was found
-      if (output === 'No stake information found. Please fund the account and try again.') {
-        // Check if the response headers have already been sent
-        if (!res.headersSent) {
-          res.status(404).json({ errorMessage: 'Account not found. Please ensure the account has been funded.', errorDetails: '' });
-        }
-        return;
-      }
       const yamlData = yaml.load(output);
       res.json(yamlData);
     })

--- a/api/handlers/node.ts
+++ b/api/handlers/node.ts
@@ -131,16 +131,14 @@ export default function configureNodeHandlers(apiRouter: Router) {
   
 
       console.log('Executing operator-cli stake_info...');
-      const output = execFileSync('operator-cli', ['stake_info', address], { encoding: 'utf8' });
+      const output = execFileSync('operator-cli', ['stake_info', address], { encoding: 'utf8' })
 
       // Check for specific error message 
       // Case where query was valid but no stake info was found
-      if (output.includes('Error: No stake information found')) {
-        console.log('Entered error handling');
+      if (output === 'No stake information found. Please fund the account and try again.') {
         // Check if the response headers have already been sent
         if (!res.headersSent) {
-          console.log('Sending 500 response: Account not found');
-          res.status(500).json({ errorMessage: 'Account not found. Please ensure the account has been created and funded.', errorDetails: '' });
+          res.status(404).json({ errorMessage: 'Account not found. Please ensure the account has been funded.', errorDetails: '' });
         }
         return;
       }

--- a/api/handlers/node.ts
+++ b/api/handlers/node.ts
@@ -128,8 +128,22 @@ export default function configureNodeHandlers(apiRouter: Router) {
         badRequestResponse(res, 'No address provided');
         return;
       }
-      console.log('executing operator-cli status...');
-      const output = execFileSync('operator-cli', ['stake_info', address], { encoding: 'utf8' })
+  
+
+      console.log('Executing operator-cli stake_info...');
+      const output = execFileSync('operator-cli', ['stake_info', address], { encoding: 'utf8' });
+
+      // Check for specific error message 
+      // Case where query was valid but no stake info was found
+      if (output.includes('Error: No stake information found')) {
+        console.log('Entered error handling');
+        // Check if the response headers have already been sent
+        if (!res.headersSent) {
+          console.log('Sending 500 response: Account not found');
+          res.status(500).json({ errorMessage: 'Account not found. Please ensure the account has been created and funded.', errorDetails: '' });
+        }
+        return;
+      }
       const yamlData = yaml.load(output);
       res.json(yamlData);
     })

--- a/hooks/fetcher.ts
+++ b/hooks/fetcher.ts
@@ -35,7 +35,7 @@ export const fetcher = async <T>(input: RequestInfo | URL,
     const data = await res.json();
     if (res.status === 403) {
       authService.logout(apiBase);
-    } else if (input.toString().includes('account') && res.status === 500 && data.errorMessage === `Account not found. Please ensure the account has been created and funded.`) {
+    } else if (input.toString().includes('account') && res.status === 404 && data.errorMessage === `Account not found. Please ensure the account has been funded.`) {
       throw new Error('No stake information found. Please fund the account and try again.');
     } else if (res.status === 500) {
       showErrorMessage('Sorry, something went wrong. Please report this issue to our support team so we can investigate and resolve the problem.');

--- a/hooks/fetcher.ts
+++ b/hooks/fetcher.ts
@@ -35,8 +35,6 @@ export const fetcher = async <T>(input: RequestInfo | URL,
     const data = await res.json();
     if (res.status === 403) {
       authService.logout(apiBase);
-    } else if (input.toString().includes('account') && res.status === 404 && data.errorMessage === `Account not found. Please ensure the account has been funded.`) {
-      throw new Error('No stake information found. Please fund the account and try again.');
     } else if (res.status === 500) {
       showErrorMessage('Sorry, something went wrong. Please report this issue to our support team so we can investigate and resolve the problem.');
       return;

--- a/hooks/fetcher.ts
+++ b/hooks/fetcher.ts
@@ -35,6 +35,8 @@ export const fetcher = async <T>(input: RequestInfo | URL,
     const data = await res.json();
     if (res.status === 403) {
       authService.logout(apiBase);
+    } else if (input.toString().includes('account') && res.status === 500 && data.errorMessage === `Account not found. Please ensure the account has been created and funded.`) {
+      throw new Error('No stake information found. Please fund the account and try again.');
     } else if (res.status === 500) {
       showErrorMessage('Sorry, something went wrong. Please report this issue to our support team so we can investigate and resolve the problem.');
       return;


### PR DESCRIPTION
https://linear.app/shm/issue/RED-318/[new-validator-design]-stake-info-throws-repeated-error-if-connected

Summary of changes: Only a log spelling change. Most changes are from CLI of this task.