### PR TITLE
RED-291: Remove tooltip from icon

### DIFF
--- a/components/organisms/OverviewSidebar.tsx
+++ b/components/organisms/OverviewSidebar.tsx
@@ -88,7 +88,6 @@ export const OverviewSidebar: React.FC = () => {
                       ? "bg-severeFg tooltip"
                       : "bg-successFg")
                   }
-                  data-tip={`Your validator version is out of date. Please update to the latest version (${version?.activeShardeumVersion})`}
                 ></div>
               </div>
               <span


### PR DESCRIPTION
Removing tooltip from validator status icon to keep it consistent with GUI version icon behavior.