### PR TITLE
Fix: wallet balance in add stake component

### DIFF
--- a/components/molecules/AddStakeModal.tsx
+++ b/components/molecules/AddStakeModal.tsx
@@ -7,6 +7,8 @@ import { useStake } from '../../hooks/useStake'
 import useModalStore from '../../hooks/useModalStore'
 import useToastStore, { ToastSeverity } from '../../hooks/useToastStore'
 import { NotificationSeverity, NotificationType } from '../../hooks/useNotificationsStore'
+import { CHAIN_ID } from '../../pages/_app'
+import { ethers } from 'ethers'
 
 export const AddStakeModal = () => {
   const { resetModal } = useModalStore((state: any) => ({
@@ -20,13 +22,18 @@ export const AddStakeModal = () => {
   const stakeInputId = 'stakeInput'
 
   const { address } = useAccount()
-  const { data } = useBalance({ address })
+  const { data } = useBalance({
+    address,
+    chainId: CHAIN_ID,
+    formatUnits: 'ether',
+  })
   const { nodeStatus } = useNodeStatus()
   const stakeInputRef = useRef<HTMLInputElement>(null)
   const [stakedAmount, setStakedAmount] = useState(0)
   const minimumStakeRequirement = useMemo(() => {
     return Math.max(parseFloat(nodeStatus?.stakeRequirement || '10') - parseFloat(nodeStatus?.lockedStake || '0'), 0)
   }, [nodeStatus?.stakeRequirement, nodeStatus?.lockedStake])
+  const [balanceData, setBalanceData] = useState<{ formatted: string; symbol: string } | null>(null)
 
   const { sendTransaction, handleStakeChange, setNomineeAddress, isEmpty, isLoading } = useStake({
     nominator: address?.toString() || '',
@@ -76,6 +83,33 @@ export const AddStakeModal = () => {
       })
     }
   }, [isLoading])
+
+  useEffect(() => {
+    const fetchCustomBalance = async () => {
+      if (address && window.ethereum) {
+        try {
+          // Use wallet provider to get balance from the active network
+          const provider = new ethers.providers.Web3Provider(window.ethereum)
+          const balance = await provider.getBalance(address)
+          setBalanceData({
+            formatted: ethers.utils.formatEther(balance),
+            symbol: 'SHM',
+          })
+        } catch (error) {
+          console.error('Error fetching balance:', error)
+          // Fall back to wagmi balance if custom fetch fails
+          if (data) {
+            setBalanceData({
+              formatted: data.formatted,
+              symbol: data.symbol,
+            })
+          }
+        }
+      }
+    }
+
+    fetchCustomBalance()
+  }, [address, data])
 
   return (
     <>
@@ -128,10 +162,12 @@ export const AddStakeModal = () => {
                 <span>Minimum stake requirement: </span>
                 <span className="font-semibold">{nodeStatus?.stakeRequirement || '10'} SHM</span>
               </div>
-              {data?.formatted && (
+              {(balanceData || data) && (
                 <div className="text-xs">
                   <span>Balance: </span>
-                  <span className="font-semibold">{`${data?.formatted} ${data?.symbol}`}</span>
+                  <span className="font-semibold">{`${balanceData?.formatted || data?.formatted} ${
+                    balanceData?.symbol || data?.symbol
+                  }`}</span>
                 </div>
               )}
             </div>

--- a/components/molecules/AddStakeModal.tsx
+++ b/components/molecules/AddStakeModal.tsx
@@ -8,7 +8,7 @@ import useModalStore from '../../hooks/useModalStore'
 import useToastStore, { ToastSeverity } from '../../hooks/useToastStore'
 import { NotificationSeverity, NotificationType } from '../../hooks/useNotificationsStore'
 import { CHAIN_ID } from '../../pages/_app'
-import { ethers } from 'ethers'
+import { useWalletBalance } from '../../hooks/useWalletBalance'
 
 export const AddStakeModal = () => {
   const { resetModal } = useModalStore((state: any) => ({
@@ -33,7 +33,9 @@ export const AddStakeModal = () => {
   const minimumStakeRequirement = useMemo(() => {
     return Math.max(parseFloat(nodeStatus?.stakeRequirement || '10') - parseFloat(nodeStatus?.lockedStake || '0'), 0)
   }, [nodeStatus?.stakeRequirement, nodeStatus?.lockedStake])
-  const [balanceData, setBalanceData] = useState<{ formatted: string; symbol: string } | null>(null)
+
+  // Use wallet balance hook for fetching balance
+  const { balanceData } = useWalletBalance(address, data)
 
   const { sendTransaction, handleStakeChange, setNomineeAddress, isEmpty, isLoading } = useStake({
     nominator: address?.toString() || '',
@@ -83,33 +85,6 @@ export const AddStakeModal = () => {
       })
     }
   }, [isLoading])
-
-  useEffect(() => {
-    const fetchCustomBalance = async () => {
-      if (address && window.ethereum) {
-        try {
-          // Use wallet provider to get balance from the active network
-          const provider = new ethers.providers.Web3Provider(window.ethereum)
-          const balance = await provider.getBalance(address)
-          setBalanceData({
-            formatted: ethers.utils.formatEther(balance),
-            symbol: 'SHM',
-          })
-        } catch (error) {
-          console.error('Error fetching balance:', error)
-          // Fall back to wagmi balance if custom fetch fails
-          if (data) {
-            setBalanceData({
-              formatted: data.formatted,
-              symbol: data.symbol,
-            })
-          }
-        }
-      }
-    }
-
-    fetchCustomBalance()
-  }, [address, data])
 
   return (
     <>

--- a/hooks/useWalletBalance.ts
+++ b/hooks/useWalletBalance.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react'
+import { ethers } from 'ethers'
+
+export interface BalanceData {
+    formatted: string
+    symbol: string
+}
+
+export const useWalletBalance = (
+    address: string | undefined,
+    fallbackData: { formatted: string; symbol: string } | null | undefined
+) => {
+    const [balanceData, setBalanceData] = useState<BalanceData | null>(null)
+
+    useEffect(() => {
+        const fetchWalletBalance = async () => {
+            if (address && window.ethereum) {
+                try {
+                    // Use wallet provider to get balance from the active network
+                    const provider = new ethers.providers.Web3Provider(window.ethereum)
+                    const balance = await provider.getBalance(address)
+                    setBalanceData({
+                        formatted: ethers.utils.formatEther(balance),
+                        symbol: 'SHM',
+                    })
+                } catch (error) {
+                    console.error('Error fetching balance:', error)
+                    // Fall back to provided fallback balance if custom fetch fails
+                    if (fallbackData) {
+                        setBalanceData({
+                            formatted: fallbackData.formatted,
+                            symbol: fallbackData.symbol,
+                        })
+                    }
+                }
+            }
+        }
+
+        fetchWalletBalance()
+    }, [address, fallbackData])
+
+    return { balanceData }
+} 

--- a/hooks/useWalletBalance.ts
+++ b/hooks/useWalletBalance.ts
@@ -2,42 +2,42 @@ import { useState, useEffect } from 'react'
 import { ethers } from 'ethers'
 
 export interface BalanceData {
-    formatted: string
-    symbol: string
+  formatted: string
+  symbol: string
 }
 
 export const useWalletBalance = (
-    address: string | undefined,
-    fallbackData: { formatted: string; symbol: string } | null | undefined
+  address: string | undefined,
+  fallbackData: { formatted: string; symbol: string } | null | undefined
 ) => {
-    const [balanceData, setBalanceData] = useState<BalanceData | null>(null)
+  const [balanceData, setBalanceData] = useState<BalanceData | null>(null)
 
-    useEffect(() => {
-        const fetchWalletBalance = async () => {
-            if (address && window.ethereum) {
-                try {
-                    // Use wallet provider to get balance from the active network
-                    const provider = new ethers.providers.Web3Provider(window.ethereum)
-                    const balance = await provider.getBalance(address)
-                    setBalanceData({
-                        formatted: ethers.utils.formatEther(balance),
-                        symbol: 'SHM',
-                    })
-                } catch (error) {
-                    console.error('Error fetching balance:', error)
-                    // Fall back to provided fallback balance if custom fetch fails
-                    if (fallbackData) {
-                        setBalanceData({
-                            formatted: fallbackData.formatted,
-                            symbol: fallbackData.symbol,
-                        })
-                    }
-                }
-            }
+  useEffect(() => {
+    const fetchWalletBalance = async () => {
+      if (address && window.ethereum) {
+        try {
+          // Use wallet provider to get balance from the active network
+          const provider = new ethers.providers.Web3Provider(window.ethereum)
+          const balance = await provider.getBalance(address)
+          setBalanceData({
+            formatted: ethers.utils.formatEther(balance),
+            symbol: 'SHM',
+          })
+        } catch (error) {
+          console.error('Error fetching balance:', error)
+          // Fall back to provided fallback balance if custom fetch fails
+          if (fallbackData) {
+            setBalanceData({
+              formatted: fallbackData.formatted,
+              symbol: fallbackData.symbol,
+            })
+          }
         }
+      }
+    }
 
-        fetchWalletBalance()
-    }, [address, fallbackData])
+    fetchWalletBalance()
+  }, [address, fallbackData])
 
-    return { balanceData }
-} 
+  return { balanceData }
+}

--- a/test/hooks/useWalletBalance.test.ts
+++ b/test/hooks/useWalletBalance.test.ts
@@ -1,0 +1,251 @@
+import { renderHook, act } from '@testing-library/react'
+import { useWalletBalance } from '../../hooks/useWalletBalance'
+
+// Mock window.ethereum
+const mockEthereum = {
+    request: jest.fn(),
+}
+
+// Mock balance value
+const MOCK_BALANCE_VALUE = '5000000000000000000' // 5 ETH in wei
+const ZERO_BALANCE = '0' // Zero balance
+
+// Mock ethers provider
+const mockGetBalance = jest.fn()
+jest.mock('ethers', () => {
+    return {
+        ethers: {
+            providers: {
+                Web3Provider: jest.fn().mockImplementation(() => ({
+                    getBalance: mockGetBalance,
+                })),
+            },
+            utils: {
+                formatEther: jest.fn((value) => {
+                    if (value === ZERO_BALANCE) return '0'
+                    return '5'
+                }),
+                parseEther: jest.fn(() => MOCK_BALANCE_VALUE),
+            },
+        },
+    }
+})
+
+describe('useWalletBalance', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        // Reset window.ethereum for each test
+        Object.defineProperty(window, 'ethereum', {
+            value: mockEthereum,
+            writable: true,
+        })
+    })
+
+    it('fetches wallet balance successfully', async () => {
+        // Mock getBalance to return a successful value
+        mockGetBalance.mockResolvedValueOnce(MOCK_BALANCE_VALUE)
+
+        const { result } = renderHook(
+            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
+            {
+                initialProps: {
+                    address: '0xmockAddress',
+                    fallbackData: null,
+                },
+            }
+        )
+
+        // Initially, balanceData should be null
+        expect(result.current.balanceData).toBeNull()
+
+        // Wait for the async effect to complete
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0))
+        })
+
+        // After the effect, balanceData should be populated
+        expect(result.current.balanceData).toEqual({
+            formatted: '5',
+            symbol: 'SHM',
+        })
+
+        // Check if getBalance was called with the correct address
+        expect(mockGetBalance).toHaveBeenCalledWith('0xmockAddress')
+    })
+
+    it('falls back to provided data if wallet fetch fails', async () => {
+        // Mock getBalance to throw an error
+        mockGetBalance.mockRejectedValueOnce(new Error('Mock Error'))
+
+        const fallbackData = { formatted: '10', symbol: 'SHM' }
+
+        const { result } = renderHook(
+            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
+            {
+                initialProps: {
+                    address: '0xmockAddress',
+                    fallbackData,
+                },
+            }
+        )
+
+        // Initially, balanceData should be null
+        expect(result.current.balanceData).toBeNull()
+
+        // Wait for the async effect to complete
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0))
+        })
+
+        // After the error, balanceData should be set to fallbackData
+        expect(result.current.balanceData).toEqual(fallbackData)
+    })
+
+    it('should not try to fetch balance if address is undefined', async () => {
+        const { result } = renderHook(
+            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
+            {
+                initialProps: {
+                    address: undefined,
+                    fallbackData: null,
+                },
+            }
+        )
+
+        // Wait for any potential async operations
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0))
+        })
+
+        // balanceData should remain null
+        expect(result.current.balanceData).toBeNull()
+        // getBalance should not be called
+        expect(mockGetBalance).not.toHaveBeenCalled()
+    })
+
+    it('should not try to fetch balance if window.ethereum is undefined', async () => {
+        // Set window.ethereum to undefined
+        Object.defineProperty(window, 'ethereum', {
+            value: undefined,
+            writable: true,
+        })
+
+        const { result } = renderHook(
+            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
+            {
+                initialProps: {
+                    address: '0xmockAddress',
+                    fallbackData: null,
+                },
+            }
+        )
+
+        // Wait for any potential async operations
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0))
+        })
+
+        // balanceData should remain null
+        expect(result.current.balanceData).toBeNull()
+        // getBalance should not be called
+        expect(mockGetBalance).not.toHaveBeenCalled()
+    })
+
+    it('handles zero balance correctly', async () => {
+        // Mock getBalance to return zero
+        mockGetBalance.mockResolvedValueOnce(ZERO_BALANCE)
+
+        const { result } = renderHook(
+            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
+            {
+                initialProps: {
+                    address: '0xmockAddress',
+                    fallbackData: null,
+                },
+            }
+        )
+
+        // Wait for the async effect to complete
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0))
+        })
+
+        // After the effect, balanceData should show zero balance
+        expect(result.current.balanceData).toEqual({
+            formatted: '0',
+            symbol: 'SHM',
+        })
+    })
+
+    it('updates balance when address changes', async () => {
+        // First render with initial address
+        mockGetBalance.mockResolvedValueOnce(MOCK_BALANCE_VALUE)
+
+        const { result, rerender } = renderHook(
+            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
+            {
+                initialProps: {
+                    address: '0xmockAddress1',
+                    fallbackData: null,
+                },
+            }
+        )
+
+        // Wait for the first fetch
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0))
+        })
+
+        expect(result.current.balanceData).toEqual({
+            formatted: '5',
+            symbol: 'SHM',
+        })
+        expect(mockGetBalance).toHaveBeenCalledWith('0xmockAddress1')
+
+        // Set up mock for second address
+        mockGetBalance.mockClear()
+        mockGetBalance.mockResolvedValueOnce(MOCK_BALANCE_VALUE)
+
+        // Rerender with new address
+        rerender({
+            address: '0xmockAddress2',
+            fallbackData: null
+        })
+
+        // Wait for the second fetch
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0))
+        })
+
+        // Should have fetched balance for the new address
+        expect(mockGetBalance).toHaveBeenCalledWith('0xmockAddress2')
+    })
+
+    it('prefers wallet balance over fallback data when available', async () => {
+        // Mock getBalance to return a successful value
+        mockGetBalance.mockResolvedValueOnce(MOCK_BALANCE_VALUE)
+
+        const fallbackData = { formatted: '10', symbol: 'SHM' }
+
+        const { result } = renderHook(
+            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
+            {
+                initialProps: {
+                    address: '0xmockAddress',
+                    fallbackData,
+                },
+            }
+        )
+
+        // Wait for the async effect to complete
+        await act(async () => {
+            await new Promise(resolve => setTimeout(resolve, 0))
+        })
+
+        // Should use wallet balance (5) instead of fallback (10)
+        expect(result.current.balanceData).toEqual({
+            formatted: '5',
+            symbol: 'SHM',
+        })
+    })
+}) 

--- a/test/hooks/useWalletBalance.test.ts
+++ b/test/hooks/useWalletBalance.test.ts
@@ -3,7 +3,7 @@ import { useWalletBalance } from '../../hooks/useWalletBalance'
 
 // Mock window.ethereum
 const mockEthereum = {
-    request: jest.fn(),
+  request: jest.fn(),
 }
 
 // Mock balance value
@@ -13,239 +13,218 @@ const ZERO_BALANCE = '0' // Zero balance
 // Mock ethers provider
 const mockGetBalance = jest.fn()
 jest.mock('ethers', () => {
-    return {
-        ethers: {
-            providers: {
-                Web3Provider: jest.fn().mockImplementation(() => ({
-                    getBalance: mockGetBalance,
-                })),
-            },
-            utils: {
-                formatEther: jest.fn((value) => {
-                    if (value === ZERO_BALANCE) return '0'
-                    return '5'
-                }),
-                parseEther: jest.fn(() => MOCK_BALANCE_VALUE),
-            },
-        },
-    }
+  return {
+    ethers: {
+      providers: {
+        Web3Provider: jest.fn().mockImplementation(() => ({
+          getBalance: mockGetBalance,
+        })),
+      },
+      utils: {
+        formatEther: jest.fn((value) => {
+          if (value === ZERO_BALANCE) return '0'
+          return '5'
+        }),
+        parseEther: jest.fn(() => MOCK_BALANCE_VALUE),
+      },
+    },
+  }
 })
 
 describe('useWalletBalance', () => {
-    beforeEach(() => {
-        jest.clearAllMocks()
-        // Reset window.ethereum for each test
-        Object.defineProperty(window, 'ethereum', {
-            value: mockEthereum,
-            writable: true,
-        })
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // Reset window.ethereum for each test
+    Object.defineProperty(window, 'ethereum', {
+      value: mockEthereum,
+      writable: true,
+    })
+  })
+
+  it('fetches wallet balance successfully', async () => {
+    // Mock getBalance to return a successful value
+    mockGetBalance.mockResolvedValueOnce(MOCK_BALANCE_VALUE)
+
+    const { result } = renderHook(({ address, fallbackData }) => useWalletBalance(address, fallbackData), {
+      initialProps: {
+        address: '0xmockAddress',
+        fallbackData: null,
+      },
     })
 
-    it('fetches wallet balance successfully', async () => {
-        // Mock getBalance to return a successful value
-        mockGetBalance.mockResolvedValueOnce(MOCK_BALANCE_VALUE)
+    // Initially, balanceData should be null
+    expect(result.current.balanceData).toBeNull()
 
-        const { result } = renderHook(
-            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
-            {
-                initialProps: {
-                    address: '0xmockAddress',
-                    fallbackData: null,
-                },
-            }
-        )
-
-        // Initially, balanceData should be null
-        expect(result.current.balanceData).toBeNull()
-
-        // Wait for the async effect to complete
-        await act(async () => {
-            await new Promise(resolve => setTimeout(resolve, 0))
-        })
-
-        // After the effect, balanceData should be populated
-        expect(result.current.balanceData).toEqual({
-            formatted: '5',
-            symbol: 'SHM',
-        })
-
-        // Check if getBalance was called with the correct address
-        expect(mockGetBalance).toHaveBeenCalledWith('0xmockAddress')
+    // Wait for the async effect to complete
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
-    it('falls back to provided data if wallet fetch fails', async () => {
-        // Mock getBalance to throw an error
-        mockGetBalance.mockRejectedValueOnce(new Error('Mock Error'))
-
-        const fallbackData = { formatted: '10', symbol: 'SHM' }
-
-        const { result } = renderHook(
-            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
-            {
-                initialProps: {
-                    address: '0xmockAddress',
-                    fallbackData,
-                },
-            }
-        )
-
-        // Initially, balanceData should be null
-        expect(result.current.balanceData).toBeNull()
-
-        // Wait for the async effect to complete
-        await act(async () => {
-            await new Promise(resolve => setTimeout(resolve, 0))
-        })
-
-        // After the error, balanceData should be set to fallbackData
-        expect(result.current.balanceData).toEqual(fallbackData)
+    // After the effect, balanceData should be populated
+    expect(result.current.balanceData).toEqual({
+      formatted: '5',
+      symbol: 'SHM',
     })
 
-    it('should not try to fetch balance if address is undefined', async () => {
-        const { result } = renderHook(
-            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
-            {
-                initialProps: {
-                    address: undefined,
-                    fallbackData: null,
-                },
-            }
-        )
+    // Check if getBalance was called with the correct address
+    expect(mockGetBalance).toHaveBeenCalledWith('0xmockAddress')
+  })
 
-        // Wait for any potential async operations
-        await act(async () => {
-            await new Promise(resolve => setTimeout(resolve, 0))
-        })
+  it('falls back to provided data if wallet fetch fails', async () => {
+    // Mock getBalance to throw an error
+    mockGetBalance.mockRejectedValueOnce(new Error('Mock Error'))
 
-        // balanceData should remain null
-        expect(result.current.balanceData).toBeNull()
-        // getBalance should not be called
-        expect(mockGetBalance).not.toHaveBeenCalled()
+    const fallbackData = { formatted: '10', symbol: 'SHM' }
+
+    const { result } = renderHook(({ address, fallbackData }) => useWalletBalance(address, fallbackData), {
+      initialProps: {
+        address: '0xmockAddress',
+        fallbackData,
+      },
     })
 
-    it('should not try to fetch balance if window.ethereum is undefined', async () => {
-        // Set window.ethereum to undefined
-        Object.defineProperty(window, 'ethereum', {
-            value: undefined,
-            writable: true,
-        })
+    // Initially, balanceData should be null
+    expect(result.current.balanceData).toBeNull()
 
-        const { result } = renderHook(
-            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
-            {
-                initialProps: {
-                    address: '0xmockAddress',
-                    fallbackData: null,
-                },
-            }
-        )
-
-        // Wait for any potential async operations
-        await act(async () => {
-            await new Promise(resolve => setTimeout(resolve, 0))
-        })
-
-        // balanceData should remain null
-        expect(result.current.balanceData).toBeNull()
-        // getBalance should not be called
-        expect(mockGetBalance).not.toHaveBeenCalled()
+    // Wait for the async effect to complete
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
-    it('handles zero balance correctly', async () => {
-        // Mock getBalance to return zero
-        mockGetBalance.mockResolvedValueOnce(ZERO_BALANCE)
+    // After the error, balanceData should be set to fallbackData
+    expect(result.current.balanceData).toEqual(fallbackData)
+  })
 
-        const { result } = renderHook(
-            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
-            {
-                initialProps: {
-                    address: '0xmockAddress',
-                    fallbackData: null,
-                },
-            }
-        )
-
-        // Wait for the async effect to complete
-        await act(async () => {
-            await new Promise(resolve => setTimeout(resolve, 0))
-        })
-
-        // After the effect, balanceData should show zero balance
-        expect(result.current.balanceData).toEqual({
-            formatted: '0',
-            symbol: 'SHM',
-        })
+  it('should not try to fetch balance if address is undefined', async () => {
+    const { result } = renderHook(({ address, fallbackData }) => useWalletBalance(address, fallbackData), {
+      initialProps: {
+        address: undefined,
+        fallbackData: null,
+      },
     })
 
-    it('updates balance when address changes', async () => {
-        // First render with initial address
-        mockGetBalance.mockResolvedValueOnce(MOCK_BALANCE_VALUE)
-
-        const { result, rerender } = renderHook(
-            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
-            {
-                initialProps: {
-                    address: '0xmockAddress1',
-                    fallbackData: null,
-                },
-            }
-        )
-
-        // Wait for the first fetch
-        await act(async () => {
-            await new Promise(resolve => setTimeout(resolve, 0))
-        })
-
-        expect(result.current.balanceData).toEqual({
-            formatted: '5',
-            symbol: 'SHM',
-        })
-        expect(mockGetBalance).toHaveBeenCalledWith('0xmockAddress1')
-
-        // Set up mock for second address
-        mockGetBalance.mockClear()
-        mockGetBalance.mockResolvedValueOnce(MOCK_BALANCE_VALUE)
-
-        // Rerender with new address
-        rerender({
-            address: '0xmockAddress2',
-            fallbackData: null
-        })
-
-        // Wait for the second fetch
-        await act(async () => {
-            await new Promise(resolve => setTimeout(resolve, 0))
-        })
-
-        // Should have fetched balance for the new address
-        expect(mockGetBalance).toHaveBeenCalledWith('0xmockAddress2')
+    // Wait for any potential async operations
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
-    it('prefers wallet balance over fallback data when available', async () => {
-        // Mock getBalance to return a successful value
-        mockGetBalance.mockResolvedValueOnce(MOCK_BALANCE_VALUE)
+    // balanceData should remain null
+    expect(result.current.balanceData).toBeNull()
+    // getBalance should not be called
+    expect(mockGetBalance).not.toHaveBeenCalled()
+  })
 
-        const fallbackData = { formatted: '10', symbol: 'SHM' }
-
-        const { result } = renderHook(
-            ({ address, fallbackData }) => useWalletBalance(address, fallbackData),
-            {
-                initialProps: {
-                    address: '0xmockAddress',
-                    fallbackData,
-                },
-            }
-        )
-
-        // Wait for the async effect to complete
-        await act(async () => {
-            await new Promise(resolve => setTimeout(resolve, 0))
-        })
-
-        // Should use wallet balance (5) instead of fallback (10)
-        expect(result.current.balanceData).toEqual({
-            formatted: '5',
-            symbol: 'SHM',
-        })
+  it('should not try to fetch balance if window.ethereum is undefined', async () => {
+    // Set window.ethereum to undefined
+    Object.defineProperty(window, 'ethereum', {
+      value: undefined,
+      writable: true,
     })
-}) 
+
+    const { result } = renderHook(({ address, fallbackData }) => useWalletBalance(address, fallbackData), {
+      initialProps: {
+        address: '0xmockAddress',
+        fallbackData: null,
+      },
+    })
+
+    // Wait for any potential async operations
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    // balanceData should remain null
+    expect(result.current.balanceData).toBeNull()
+    // getBalance should not be called
+    expect(mockGetBalance).not.toHaveBeenCalled()
+  })
+
+  it('handles zero balance correctly', async () => {
+    // Mock getBalance to return zero
+    mockGetBalance.mockResolvedValueOnce(ZERO_BALANCE)
+
+    const { result } = renderHook(({ address, fallbackData }) => useWalletBalance(address, fallbackData), {
+      initialProps: {
+        address: '0xmockAddress',
+        fallbackData: null,
+      },
+    })
+
+    // Wait for the async effect to complete
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    // After the effect, balanceData should show zero balance
+    expect(result.current.balanceData).toEqual({
+      formatted: '0',
+      symbol: 'SHM',
+    })
+  })
+
+  it('updates balance when address changes', async () => {
+    // First render with initial address
+    mockGetBalance.mockResolvedValueOnce(MOCK_BALANCE_VALUE)
+
+    const { result, rerender } = renderHook(({ address, fallbackData }) => useWalletBalance(address, fallbackData), {
+      initialProps: {
+        address: '0xmockAddress1',
+        fallbackData: null,
+      },
+    })
+
+    // Wait for the first fetch
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(result.current.balanceData).toEqual({
+      formatted: '5',
+      symbol: 'SHM',
+    })
+    expect(mockGetBalance).toHaveBeenCalledWith('0xmockAddress1')
+
+    // Set up mock for second address
+    mockGetBalance.mockClear()
+    mockGetBalance.mockResolvedValueOnce(MOCK_BALANCE_VALUE)
+
+    // Rerender with new address
+    rerender({
+      address: '0xmockAddress2',
+      fallbackData: null,
+    })
+
+    // Wait for the second fetch
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    // Should have fetched balance for the new address
+    expect(mockGetBalance).toHaveBeenCalledWith('0xmockAddress2')
+  })
+
+  it('prefers wallet balance over fallback data when available', async () => {
+    // Mock getBalance to return a successful value
+    mockGetBalance.mockResolvedValueOnce(MOCK_BALANCE_VALUE)
+
+    const fallbackData = { formatted: '10', symbol: 'SHM' }
+
+    const { result } = renderHook(({ address, fallbackData }) => useWalletBalance(address, fallbackData), {
+      initialProps: {
+        address: '0xmockAddress',
+        fallbackData,
+      },
+    })
+
+    // Wait for the async effect to complete
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    // Should use wallet balance (5) instead of fallback (10)
+    expect(result.current.balanceData).toEqual({
+      formatted: '5',
+      symbol: 'SHM',
+    })
+  })
+})


### PR DESCRIPTION
### **User description**
Use wallet provider to get balance from the active network otherwise fallback to wagmi


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implement custom balance fetching using wallet provider.

- Add fallback to wagmi balance if custom fetch fails.

- Update balance display logic in AddStakeModal.

- Introduce state to manage balance data.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddStakeModal.tsx</strong><dd><code>Enhance balance fetching and error handling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/molecules/AddStakeModal.tsx

<li>Implement custom balance fetching with ethers.js.<br> <li> Add fallback mechanism for balance retrieval.<br> <li> Update balance display to use new balance data state.<br> <li> Introduce useEffect to manage balance fetching logic.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/103/files#diff-84bca6181ab22d64476705583a9f08c1471eed5bb696b7cc2310afb28b49f3ff">+39/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>