### PR TITLE
SHARD-2140: add unstakeCooldown logic

### DIFF
--- a/components/molecules/StakeDisplay.tsx
+++ b/components/molecules/StakeDisplay.tsx
@@ -11,6 +11,7 @@ import { ClipboardIcon } from '../atoms/ClipboardIcon'
 import { MobileModalWrapper } from '../layouts/MobileModalWrapper'
 import { useAccountStakeInfo } from '../../hooks/useAccountStakeInfo'
 import { Constants } from '../../utils/constants'
+import { useLocalStorage } from '../../hooks/useLocalStorage'
 
 export const StakeDisplay = () => {
   const addressRef = useRef<HTMLSpanElement>(null)
@@ -24,6 +25,7 @@ export const StakeDisplay = () => {
     resetModal: state.resetModal,
   }))
   const [hasNodeStopped, setHasNodeStopped] = useState(false)
+  const [lastUnstake] = useLocalStorage(Constants.UNSTAKE_COOLDOWN_KEY, '0')
 
   useEffect(() => {
     if (nodeStatus?.state === 'stopped') {
@@ -32,17 +34,6 @@ export const StakeDisplay = () => {
       setHasNodeStopped(false)
     }
   }, [nodeStatus?.state])
-
-  useEffect(() => {
-    const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === Constants.UNSTAKE_COOLDOWN_KEY) {
-        setLastUnstake(e.newValue ? parseInt(e.newValue) : 0)
-      }
-    }
-
-    window.addEventListener('storage', handleStorageChange)
-    return () => window.removeEventListener('storage', handleStorageChange)
-  }, [])
 
   const formatRemainingTime = (ms: number) => {
     const minutes = Math.floor(ms / 60000)
@@ -56,11 +47,6 @@ export const StakeDisplay = () => {
   }
 
   const stakeForConnectedAddressOrNode = parseFloat(stakeInfo?.stake?.trim() || nodeStatus?.lockedStake || '0')
-  const [lastUnstake, setLastUnstake] = useState(
-    localStorage.getItem(Constants.UNSTAKE_COOLDOWN_KEY)
-      ? parseInt(localStorage.getItem(Constants.UNSTAKE_COOLDOWN_KEY)!)
-      : 0
-  )
   const hasStakeOnDifferentNode =
     parseFloat(stakeInfo?.stake ?? '0.0') > parseFloat('0.0') &&
     nodeStatus?.nomineeAddress != null &&
@@ -71,7 +57,7 @@ export const StakeDisplay = () => {
     if (!stakeInfo || stakeInfo?.unstakeInterval == null || stakeInfo?.unstakeInterval <= 0) {
       return 0
     }
-    const lastUnstakeTime = lastUnstake ? lastUnstake : 0
+    const lastUnstakeTime = lastUnstake ? parseInt(lastUnstake) : 0
     const cooldown = stakeInfo.unstakeInterval - (Date.now() - lastUnstakeTime)
     return cooldown > 0 ? cooldown : 0
   }

--- a/components/molecules/StakeDisplay.tsx
+++ b/components/molecules/StakeDisplay.tsx
@@ -1,5 +1,5 @@
 import { Card } from '../layouts/Card'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useAccount, useNetwork } from 'wagmi'
 import { useNodeStatus } from '../../hooks/useNodeStatus'
 import useModalStore from '../../hooks/useModalStore'
@@ -10,6 +10,7 @@ import { ConfirmUnstakeModal } from './ConfirmUnstakeModal'
 import { ClipboardIcon } from '../atoms/ClipboardIcon'
 import { MobileModalWrapper } from '../layouts/MobileModalWrapper'
 import { useAccountStakeInfo } from '../../hooks/useAccountStakeInfo'
+import { Constants } from '../../utils/constants'
 
 export const StakeDisplay = () => {
   const addressRef = useRef<HTMLSpanElement>(null)
@@ -32,6 +33,17 @@ export const StakeDisplay = () => {
     }
   }, [nodeStatus?.state])
 
+  useEffect(() => {
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === Constants.UNSTAKE_COOLDOWN_KEY) {
+        setLastUnstake(e.newValue ? parseInt(e.newValue) : 0)
+      }
+    }
+
+    window.addEventListener('storage', handleStorageChange)
+    return () => window.removeEventListener('storage', handleStorageChange)
+  }, [])
+
   const formatRemainingTime = (ms: number) => {
     const minutes = Math.floor(ms / 60000)
     let seconds = Math.floor((ms % 60000) / 1000)
@@ -44,14 +56,49 @@ export const StakeDisplay = () => {
   }
 
   const stakeForConnectedAddressOrNode = parseFloat(stakeInfo?.stake?.trim() || nodeStatus?.lockedStake || '0')
+  const [lastUnstake, setLastUnstake] = useState(
+    localStorage.getItem(Constants.UNSTAKE_COOLDOWN_KEY)
+      ? parseInt(localStorage.getItem(Constants.UNSTAKE_COOLDOWN_KEY)!)
+      : 0
+  )
   const hasStakeOnDifferentNode =
     parseFloat(stakeInfo?.stake ?? '0.0') > parseFloat('0.0') &&
     nodeStatus?.nomineeAddress != null &&
     stakeInfo?.nominee !== nodeStatus?.nomineeAddress
 
+  function calcCooldown() {
+    // use Date.now, config from stakeInfo.unstakeInterval and lastUnstake to calculate the cooldown
+    if (!stakeInfo || stakeInfo?.unstakeInterval == null || stakeInfo?.unstakeInterval <= 0) {
+      return 0
+    }
+    const lastUnstakeTime = lastUnstake ? lastUnstake : 0
+    const cooldown = stakeInfo.unstakeInterval - (Date.now() - lastUnstakeTime)
+    return cooldown > 0 ? cooldown : 0
+  }
+
+  const cooldown = calcCooldown()
+
   const isRemoveButtonDisabled =
     (!hasStakeOnDifferentNode && (!hasNodeStopped || !nodeStatus?.stakeState || !nodeStatus?.stakeState.unlocked)) ||
-    stakeForConnectedAddressOrNode === 0
+    stakeForConnectedAddressOrNode === 0 ||
+    cooldown > 0
+
+  function unstakeTooltip() {
+    if (hasNodeStopped) {
+      if (nodeStatus?.stakeState?.unlocked === false && nodeStatus?.stakeState?.remainingTime > 0) {
+        return `Node is currently stopped and is being removed from the active validator list. Please wait for another ${formatRemainingTime(
+          nodeStatus.stakeState.remainingTime
+        )} before you can remove your stake.`
+      }
+
+      if (cooldown > 0) {
+        return `You have recently removed your stake. Please wait for another ${formatRemainingTime(
+          cooldown
+        )} before you can remove your stake.`
+      }
+    }
+    return 'It is not recommended to unstake while validating. If absolutely necessary, use the force remove option in settings to remove stake (Not Recommended).'
+  }
 
   return (
     <Card>
@@ -102,15 +149,7 @@ export const StakeDisplay = () => {
                         }
                         ${isRemoveButtonDisabled ? 'tooltip tooltip-bottom' : ''}
                       `}
-                      data-tip={
-                        hasNodeStopped &&
-                        nodeStatus?.stakeState?.unlocked === false &&
-                        nodeStatus?.stakeState?.remainingTime > 0
-                          ? `Node is currently stopped and is being removed from the active validator list. Please wait for another ${formatRemainingTime(
-                              nodeStatus.stakeState.remainingTime
-                            )} before you can remove your stake.`
-                          : 'It is not recommended to unstake while validating. If absolutely necessary, use the force remove option in settings to remove stake (Not Recommended).'
-                      }
+                      data-tip={unstakeTooltip()}
                       disabled={isRemoveButtonDisabled}
                       onClick={() => {
                         resetModal()

--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -1,0 +1,29 @@
+import create from 'zustand'
+
+const stores: any = {}
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  // Create or reuse a store for this key
+  if (!stores[key]) {
+    stores[key] = create<{ value: T; setValue: (newValue: T | ((prev: T) => T)) => void }>()((set) => ({
+      value: JSON.parse(localStorage.getItem(key) ?? JSON.stringify(initialValue)),
+      setValue: (newValue: T | ((prev: T) => T)) => {
+        set((state) => {
+          const valueToStore = typeof newValue === 'function' ? (newValue as (prev: T) => T)(state.value) : newValue
+
+          localStorage.setItem(key, JSON.stringify(valueToStore))
+          return { value: valueToStore }
+        })
+      },
+    }))
+  }
+
+  // Get current state and setter from the store
+  const state = stores[key]((state: { value: T }) => state.value)
+  const setState = stores[key](
+    (state: { value: T; setValue: (newValue: T | ((prev: T) => T)) => void }) => state.setValue
+  )
+
+  // Return as array to match useState pattern
+  return [state, setState]
+}

--- a/hooks/useStake.ts
+++ b/hooks/useStake.ts
@@ -4,6 +4,7 @@ import { useTXLogs } from './useTXLogs'
 import { isMetaMaskError } from '../utils/isMetaMaskError'
 import { isEthersError } from '../utils/isEthersError'
 import { ExternalProvider } from '@ethersproject/providers'
+import { Constants } from '../utils/constants'
 
 type useStakeProps = {
   nominator: string
@@ -87,6 +88,7 @@ export const useStake = ({ nominator, nominee, stakeAmount, onStake, totalStaked
       console.log('Params: ', params)
 
       const { hash, data: resultData, wait } = await signer.sendTransaction(params)
+      localStorage.setItem(Constants.UNSTAKE_COOLDOWN_KEY, Date.now().toString())
       console.log('TX RECEIPT: ', { hash, resultData })
       await writeStakeLog(createStakeLog(blobData, params, hash, from))
 

--- a/hooks/useStake.ts
+++ b/hooks/useStake.ts
@@ -1,10 +1,7 @@
 import { ChangeEvent, useEffect, useState } from 'react'
 import { ethers } from 'ethers'
 import { useTXLogs } from './useTXLogs'
-import { isMetaMaskError } from '../utils/isMetaMaskError'
-import { isEthersError } from '../utils/isEthersError'
 import { ExternalProvider } from '@ethersproject/providers'
-import { Constants } from '../utils/constants'
 
 type useStakeProps = {
   nominator: string
@@ -88,7 +85,6 @@ export const useStake = ({ nominator, nominee, stakeAmount, onStake, totalStaked
       console.log('Params: ', params)
 
       const { hash, data: resultData, wait } = await signer.sendTransaction(params)
-      localStorage.setItem(Constants.UNSTAKE_COOLDOWN_KEY, Date.now().toString())
       console.log('TX RECEIPT: ', { hash, resultData })
       await writeStakeLog(createStakeLog(blobData, params, hash, from))
 

--- a/hooks/useUnstake.ts
+++ b/hooks/useUnstake.ts
@@ -8,6 +8,7 @@ import { ExternalProvider } from '@ethersproject/providers'
 import { Address } from 'wagmi'
 import { showErrorMessage, showSuccessMessage } from './useToastStore'
 import { Constants } from '../utils/constants'
+import { useLocalStorage } from './useLocalStorage'
 
 type useStakeProps = {
   nominator: string
@@ -16,6 +17,7 @@ type useStakeProps = {
 }
 
 export const useUnstake = ({ nominator, nominee, force }: useStakeProps) => {
+  const [, setLastUnstake] = useLocalStorage(Constants.UNSTAKE_COOLDOWN_KEY, '0')
   const { writeUnstakeLog } = useTXLogs()
   const ethereum = window.ethereum
 
@@ -63,7 +65,7 @@ export const useUnstake = ({ nominator, nominee, force }: useStakeProps) => {
       console.log('Params: ', params)
 
       const { hash, data, wait } = await signer.sendTransaction(params)
-      localStorage.setItem(Constants.UNSTAKE_COOLDOWN_KEY, Date.now().toString())
+      setLastUnstake(Date.now().toString())
       console.log('TX RECEIPT: ', { hash, data })
       await writeUnstakeLog(createUnstakeLog(unstakeData, params, hash, from))
 

--- a/hooks/useUnstake.ts
+++ b/hooks/useUnstake.ts
@@ -7,6 +7,7 @@ import { isEthersError } from '../utils/isEthersError'
 import { ExternalProvider } from '@ethersproject/providers'
 import { Address } from 'wagmi'
 import { showErrorMessage, showSuccessMessage } from './useToastStore'
+import { Constants } from '../utils/constants'
 
 type useStakeProps = {
   nominator: string
@@ -62,6 +63,7 @@ export const useUnstake = ({ nominator, nominee, force }: useStakeProps) => {
       console.log('Params: ', params)
 
       const { hash, data, wait } = await signer.sendTransaction(params)
+      localStorage.setItem(Constants.UNSTAKE_COOLDOWN_KEY, Date.now().toString())
       console.log('TX RECEIPT: ', { hash, data })
       await writeUnstakeLog(createUnstakeLog(unstakeData, params, hash, from))
 

--- a/model/account-stake-info.ts
+++ b/model/account-stake-info.ts
@@ -2,4 +2,5 @@ export interface AccountStakeInfo {
   stake: string
   nominee: string
   rewards: string
+  unstakeInterval: number
 }

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,0 +1,3 @@
+export const Constants = {
+    UNSTAKE_COOLDOWN_KEY: 'lastUnstake'
+}


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Implemented unstake cooldown logic in `StakeDisplay`.

- Added `unstakeInterval` to `AccountStakeInfo` model.

- Introduced `Constants` for managing local storage keys.

- Enhanced tooltip logic for unstake button.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StakeDisplay.tsx</strong><dd><code>Implement unstake cooldown and enhance tooltips</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/molecules/StakeDisplay.tsx

<li>Added unstake cooldown logic and tooltip updates.<br> <li> Introduced <code>Constants</code> for local storage management.<br> <li> Modified button disable logic based on cooldown.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/106/files#diff-43720225c208b87686fb4dc52e5e595716722ddb5ccff33899f0f81d823ebe4f">+50/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useUnstake.ts</strong><dd><code>Add unstake cooldown storage logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hooks/useUnstake.ts

<li>Set local storage item for unstake cooldown.<br> <li> Imported <code>Constants</code> for local storage key management.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/106/files#diff-402be3e9a29e3347cb24406c9b5470bf8d98804606f23f9e417f69a41fcc6ab4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>account-stake-info.ts</strong><dd><code>Extend AccountStakeInfo with unstakeInterval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

model/account-stake-info.ts

- Added `unstakeInterval` property to interface.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/106/files#diff-67b6e5e7620865406710c3151858ff1a0f40135eddd4161c4ef1cf055d3191ee">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useStake.ts</strong><dd><code>Clean up unused imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hooks/useStake.ts

- Removed unused error handling imports.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/106/files#diff-cb882524a101fbd1e9a23cd99641c70cf8366b4b34cd7494eaf73e3553d1624d">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constants.ts</strong><dd><code>Add Constants for local storage keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/constants.ts

- Introduced `Constants` object for key management.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/106/files#diff-0e60e507a85597f50580c441af98295d4ae9e0271cf4a7df2d3741c6448fd00e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>