### PR TITLE
SHARD-1842: better error messaging around Stake Lock 

### DIFF
--- a/components/molecules/StakeDisplay.tsx
+++ b/components/molecules/StakeDisplay.tsx
@@ -63,6 +63,8 @@ export const StakeDisplay = () => {
   }
 
   const cooldown = calcCooldown()
+  const isStakeLocked = nodeStatus?.stakeState?.unlocked === false && nodeStatus?.stakeState?.remainingTime > 0
+  const isRestakeForbidden = nodeStatus?.stakeable?.restakeAllowed === false && nodeStatus?.stakeable?.remainingTime > 0
 
   const isRemoveButtonDisabled =
     (!hasStakeOnDifferentNode && (!hasNodeStopped || !nodeStatus?.stakeState || !nodeStatus?.stakeState.unlocked)) ||
@@ -71,7 +73,7 @@ export const StakeDisplay = () => {
 
   function unstakeTooltip() {
     if (hasNodeStopped) {
-      if (nodeStatus?.stakeState?.unlocked === false && nodeStatus?.stakeState?.remainingTime > 0) {
+      if (isStakeLocked) {
         return `Node is currently stopped and is being removed from the active validator list. Please wait for another ${formatRemainingTime(
           nodeStatus.stakeState.remainingTime
         )} before you can remove your stake.`
@@ -162,11 +164,11 @@ export const StakeDisplay = () => {
                     <button
                       className={
                         'px-3 py-2 rounded text-sm basis-0 grow max-w-[12rem] ' +
-                        (hasNodeStopped || !nodeStatus?.nomineeAddress
+                        (hasNodeStopped || !nodeStatus?.nomineeAddress || isRestakeForbidden
                           ? 'text-gray-400 border border-bodyFg'
                           : 'bg-primary text-white')
                       }
-                      disabled={hasNodeStopped || !nodeStatus?.nomineeAddress}
+                      disabled={hasNodeStopped || !nodeStatus?.nomineeAddress || isRestakeForbidden}
                       onClick={() => {
                         resetModal()
                         setContent(
@@ -194,6 +196,13 @@ export const StakeDisplay = () => {
               for the current node.
             </span>
           </div>
+        )}
+        {isRestakeForbidden && (
+            <div className={`flex gap-x-2 items-center px-4 py-2 bg-dangerBg border-gray-200 border-t`}>
+            <span className="bodyFg font-light text-xs ">
+              Restaking is on cooldown. Please wait for another {formatRemainingTime(nodeStatus?.stakeable?.remainingTime)} before you can add more stake.
+            </span>
+            </div>
         )}
       </>
     </Card>

--- a/model/node-status.ts
+++ b/model/node-status.ts
@@ -13,6 +13,11 @@ export interface NodeStatus {
     reason: string
     remainingTime: number
   }
+  stakeable: {
+    reason: string
+    remainingTime: number
+    restakeAllowed: boolean
+  }
   stakeAddress: string
   stakeRequirement: string
   nominatorAddress: string


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `stakeable` field to `NodeStatus` for restake cooldown.

- Implemented `isStakeLocked` and `isRestakeForbidden` checks in `StakeDisplay`.

- Updated UI to display restake cooldown messages.

- Refactored tooltip logic for stake lock status.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StakeDisplay.tsx</strong><dd><code>Implement stake lock and restake cooldown logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/molecules/StakeDisplay.tsx

<li>Added <code>isStakeLocked</code> and <code>isRestakeForbidden</code> checks.<br> <li> Updated button states and tooltips based on stake status.<br> <li> Displayed cooldown messages for restaking.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/110/files#diff-43720225c208b87686fb4dc52e5e595716722ddb5ccff33899f0f81d823ebe4f">+12/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>node-status.ts</strong><dd><code>Extend NodeStatus with restake cooldown properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

model/node-status.ts

<li>Added <code>stakeable</code> field to <code>NodeStatus</code>.<br> <li> Included restake cooldown properties.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/110/files#diff-c70a8a6bdcc877f455f1f076161df33aafe8580a11c16cc5625f431ddf8901eb">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>