### PR TITLE
SHARD-2433: move away from GUI/CLI versioning in favour of docker image…

### DIFF
--- a/components/molecules/InformationPopupsDisplay.tsx
+++ b/components/molecules/InformationPopupsDisplay.tsx
@@ -7,7 +7,6 @@ import greyLogo from '../../assets/grey-logo.svg'
 import useNotificationsStore, { NotificationSeverity, NotificationType } from '../../hooks/useNotificationsStore'
 
 const newGuiVersionAvailableKey = 'newGuiVersionAvailable'
-const newValidatorVersionAvailableKey = 'newValidatorVersionAvailable'
 
 const VERSION_UPDATE_REPOSITORY_URL =
   process.env.VERSION_UPDATE_REPOSITORY_URL ?? 'https://github.com/shardeum/validator-dashboard'
@@ -19,13 +18,9 @@ export const InformationPopupsDisplay = () => {
   const { version } = useNodeVersion()
 
   useEffect(() => {
-    const newGuiAvailable =
-      process.env.NEXT_PUBLIC_IGNORE_PRERELEASE === 'false'
-        ? (version?.runningCliVersion || 0) < (version?.latestCliVersion || 0)
-        : !version?.latestCliVersion?.includes('prerelease') &&
-          (version?.runningCliVersion || 0) < (version?.latestCliVersion || 0)
-
-    const newValidatorAvailable = (version?.runnningValidatorVersion || 0) < (version?.activeShardeumVersion || 0)
+    const newGuiAvailable = version?.currentImageDigest &&
+      version?.latestImageDigest &&
+      version?.currentImageDigest !== version?.latestImageDigest
 
     if (newGuiAvailable) {
       addNotification({
@@ -54,40 +49,10 @@ export const InformationPopupsDisplay = () => {
         })
       }
     }
-
-    if (newValidatorAvailable) {
-      addNotification({
-        type: NotificationType.VERSION_UPDATE,
-        severity: NotificationSeverity.ATTENTION,
-        title: 'New Validator version available',
-      })
-
-      const wasNewValidatorVersionPreviouslyAvailable = localStorage.getItem(newValidatorVersionAvailableKey) === 'true'
-      if (!wasNewValidatorVersionPreviouslyAvailable) {
-        // user viewing this for the first time
-        setShowValidatorUpdatePrompt(true)
-        localStorage.setItem(newValidatorVersionAvailableKey, 'true')
-        //TODO: if it's not in pending notifications, add it to pending notifications
-      }
-    } else {
-      const wasNewValidatorVersionPreviouslyAvailable = localStorage.getItem(newValidatorVersionAvailableKey) === 'true'
-      if (wasNewValidatorVersionPreviouslyAvailable) {
-        localStorage.removeItem(newValidatorVersionAvailableKey)
-        setShowValidatorUpdated(true)
-        setShowValidatorUpdatePrompt(false)
-        addNotification({
-          type: NotificationType.VERSION_UPDATE,
-          severity: NotificationSeverity.SUCCESS,
-          title: `Your validator version has been updated to Version: ${version?.runnningValidatorVersion}`,
-        })
-      }
-    }
   }, [version])
 
   const [showGuiUpdatePrompt, setShowGuiUpdatePrompt] = useState(false)
-  const [showValidatorUpdatePrompt, setShowValidatorUpdatePrompt] = useState(false)
   const [showGuiUpdated, setShowGuiUpdated] = useState(false)
-  const [showValidatorUpdated, setShowValidatorUpdated] = useState(false)
 
   const isOnboardingCompleted = localStorage.getItem(onboardingCompletedKey) === 'true'
 
@@ -125,45 +90,13 @@ export const InformationPopupsDisplay = () => {
         </div>
       )}
       {!showOnboardingPrompt && <span className="text-4xl font-semibold">Welcome Validator!</span>}
-      {showValidatorUpdatePrompt && (
-        <div className="w-full h-full shadow border border-attentionBorder bg-attentionBg rounded p-4">
-          <div className="flex flex-col">
-            <div className="flex flex-col">
-              <span className="font-semibold text-xs">New validator version available</span>
-              <span className="bodyFg font-light text-xs">
-                A new validator version (V {version?.activeShardeumVersion}) is available and ready to update.
-              </span>
-            </div>
-            <div className="flex justify-end gap-x-3 w-full mt-2">
-              <button
-                className="text-xs px-3 py-2"
-                onClick={() => {
-                  setShowValidatorUpdatePrompt(false)
-                }}
-              >
-                Dismiss
-              </button>
-              <Link
-                href={VERSION_UPDATE_REPOSITORY_URL}
-                onClick={() => {
-                  setShowValidatorUpdatePrompt(false)
-                }}
-                target="_blank"
-                className="flex justify-center items-center bg-white border border-gray-300 rounded text-xs font-semibold w-24 py-1"
-              >
-                Update
-              </Link>
-            </div>
-          </div>
-        </div>
-      )}
-      {showGuiUpdatePrompt && (
+      {showGuiUpdatePrompt && version?.latestImageDigest && (
         <div className="w-full h-full shadow border border-attentionBorder bg-attentionBg rounded p-4">
           <div className="flex flex-col">
             <div className="flex flex-col">
               <span className="font-semibold text-xs">New GUI version available</span>
               <span className="bodyFg font-light text-xs">
-                A new GUI version (V {version?.latestCliVersion}) is available and ready to update.
+                A new GUI version (Image Digest: {version?.latestImageDigest}) is available and ready to update.
               </span>
             </div>
             <div className="flex justify-end gap-x-3 w-full mt-2">
@@ -185,28 +118,6 @@ export const InformationPopupsDisplay = () => {
               >
                 Update
               </Link>
-            </div>
-          </div>
-        </div>
-      )}
-      {showValidatorUpdated && (
-        <div className="w-full h-full shadow border border-successBorder bg-successBg rounded p-4">
-          <div className="flex flex-col">
-            <div className="flex flex-col">
-              <span className="font-semibold text-xs">Validator version has been updated</span>
-              <span className="bodyFg font-light text-xs">
-                Your validator has been updated to Version {version?.runnningValidatorVersion} and is ready to be used.
-              </span>
-            </div>
-            <div className="flex justify-end gap-x-3 w-full">
-              <button
-                className="text-xs px-3 py-2"
-                onClick={() => {
-                  setShowValidatorUpdated(false)
-                }}
-              >
-                Dismiss
-              </button>
             </div>
           </div>
         </div>

--- a/components/organisms/OverviewSidebar.tsx
+++ b/components/organisms/OverviewSidebar.tsx
@@ -6,29 +6,7 @@ import { useNodeVersion } from '../../hooks/useNodeVersion'
 import { useRef, useState } from 'react'
 import { SupportDisplay } from '../molecules/SupportDisplay'
 import { NodeStatusUpdate } from '../atoms/NodeStatusUpdate'
-
-function compareVersions(version1?: string, version2?: string) {
-  if (!version1 || !version2) {
-    console.error('Invalid version string(s) provided:', {
-      version1,
-      version2,
-    })
-    return 0 // return 0 in this case to avoid falsly indicating a version mismatch when one of the versions is missing
-  }
-
-  const v1Parts = version1.split('.').map(Number)
-  const v2Parts = version2.split('.').map(Number)
-
-  for (let i = 0; i < Math.max(v1Parts.length, v2Parts.length); i++) {
-    const v1Part = v1Parts[i] || 0 // Default to 0 if part is missing
-    const v2Part = v2Parts[i] || 0 // Default to 0 if part is missing
-
-    if (v1Part < v2Part) return -1
-    if (v1Part > v2Part) return 1
-  }
-
-  return 0 // Versions are equal
-}
+import { truncateMiddle } from '../../utils/truncateMiddle'
 
 export const OverviewSidebar: React.FC = () => {
   const renderCount = useRef(0)
@@ -39,12 +17,9 @@ export const OverviewSidebar: React.FC = () => {
   const [areSupportOptionsVisible, setAreSupportOptionsVisible] = useState(false)
 
   const isGuiUpdatePending =
-    process.env.NEXT_PUBLIC_IGNORE_PRERELEASE === 'false'
-      ? version?.runningCliVersion !== version?.latestCliVersion
-      : !version?.latestCliVersion.includes('prerelease') && version?.runningCliVersion !== version?.latestCliVersion
-
-  const isValidatorUpdatePending =
-    compareVersions(version?.runnningValidatorVersion, version?.minShardeumVersion) === -1
+    version?.currentImageDigest &&
+    version?.latestImageDigest &&
+    version?.currentImageDigest !== version?.latestImageDigest
 
   return (
     <div className="flex flex-col gap-y-16 scroll-smooth">
@@ -80,30 +55,30 @@ export const OverviewSidebar: React.FC = () => {
               </div>
               <span
                 className={`font-light text-xs ${isGuiUpdatePending ? 'tooltip' : ''}`}
-                data-tip={`Your GUI version is out of date. Please update to the latest version (${version?.latestCliVersion})`}
+                data-tip={`Your GUI version is out of date. Please update to the latest version (${version?.latestImageDigest})`}
               >
-                GUI Version <u>{version?.runningGuiVersion}</u>
+                Current Image Digest <u title={version?.currentImageDigest}>{truncateMiddle(version?.currentImageDigest, 12, 10)}</u>
               </span>
             </div>
             <div className="flex items-center gap-x-2">
               <div
                 className={
                   'rounded-full h-2 w-2 flex items-center justify-center ' +
-                  (isValidatorUpdatePending ? 'bg-severeBorder' : 'bg-successBorder')
+                  (isGuiUpdatePending ? 'bg-severeBorder' : 'bg-successBorder')
                 }
               >
                 <div
                   className={
-                    'rounded-full h-1 w-1 ' + (isValidatorUpdatePending ? 'bg-severeFg tooltip' : 'bg-successFg')
+                    'rounded-full h-1 w-1 ' + (isGuiUpdatePending ? 'bg-severeFg tooltip' : 'bg-successFg')
                   }
-                  data-tip={`Your validator version is out of date. Please update to the latest version (${version?.activeShardeumVersion})`}
+                  data-tip={`Your validator version is out of date. Please update to the latest version (${version?.latestImageDigest})`}
                 ></div>
               </div>
               <span
                 className={`font-light text-xs ${isGuiUpdatePending ? 'tooltip' : ''}`}
-                data-tip={`Your Validator version is out of date. Please update to the latest version (${version?.activeShardeumVersion})`}
+                data-tip={`Your Validator version is out of date. Please update to the latest version (${version?.latestImageDigest})`}
               >
-                Validator Version <u>{version?.runnningValidatorVersion}</u>
+                Latest Image Digest <u title={version?.latestImageDigest}>{truncateMiddle(version?.latestImageDigest, 12, 10)}</u>
               </span>
             </div>
           </div>

--- a/model/node-version.ts
+++ b/model/node-version.ts
@@ -8,4 +8,6 @@ export interface NodeVersion {
   runnningValidatorVersion: string
   minShardeumVersion: string
   activeShardeumVersion: string
+  currentImageDigest: string
+  latestImageDigest: string
 }

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -28,8 +28,6 @@ const Login = () => {
     }
   }
 
-  const { version } = useNodeVersion(true)
-
   return (
     <div className="flex flex-col h-screen justify-between relative">
       <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -69,12 +67,6 @@ const Login = () => {
               />
               <div className="flex flex-col justify-between h-full">
                 <LoginForm />
-                {!isMobile && (
-                  <div className="flex justify-between w-full">
-                    <span>Validator Version : {version?.runnningValidatorVersion}</span>
-                    <span>Running on Localhost</span>
-                  </div>
-                )}
               </div>
             </div>
           </main>

--- a/utils/truncateMiddle.ts
+++ b/utils/truncateMiddle.ts
@@ -1,0 +1,7 @@
+export function truncateMiddle(str: string | null | undefined, front = 4, back = 4) {
+  if (str == null) {
+    return ''
+  }
+  if (str.length <= front + back) return str
+  return str.slice(0, front) + '...' + str.slice(-back)
+}


### PR DESCRIPTION
### **User description**
… digest


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored version checks to use Docker image digests, not CLI versions

- Removed validator version update prompts and logic from UI

- Updated sidebar to display image digests with truncation utility

- Added `truncateMiddle` utility for digest display formatting


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InformationPopupsDisplay.tsx</strong><dd><code>Refactor GUI update logic to use image digests, remove validator </code><br><code>update UI</code></dd></summary>
<hr>

components/molecules/InformationPopupsDisplay.tsx

<li>Replaced GUI version update logic to compare Docker image digests<br> <li> Removed all validator version update checks and prompts<br> <li> Updated GUI update prompt to show image digest instead of version<br> <li> Cleaned up unused state and notification logic for validator updates


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/122/files#diff-b76b1d142508d73386a9e3eb66c061473e6e64b8529487847245e7a667fbd68c">+5/-94</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OverviewSidebar.tsx</strong><dd><code>Update sidebar to display and compare Docker image digests</code></dd></summary>
<hr>

components/organisms/OverviewSidebar.tsx

<li>Removed version string comparison logic and validator update checks<br> <li> Updated GUI/validator status to use image digests and truncation<br> <li> Replaced version numbers with image digest display in sidebar<br> <li> Integrated new <code>truncateMiddle</code> utility for digest formatting


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/122/files#diff-55aa85cc54b11597f346eeb9feabe3aeb82e9cb4b7820763292e5ec8c1d330c3">+11/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>node-version.ts</strong><dd><code>Add image digest fields to NodeVersion model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

model/node-version.ts

<li>Added <code>currentImageDigest</code> and <code>latestImageDigest</code> to NodeVersion <br>interface


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/122/files#diff-0fbc271c4fd5f86eb3bf09818e8584d775c292bc0ee419ceef5826347efe0cc7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Remove validator version info from login page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pages/login/index.tsx

<li>Removed validator version display from login page<br> <li> Cleaned up unused version hook


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/122/files#diff-3445c249077db6f09711614dae5d5480bca41b745cb4aa465b0886f189dfd72d">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>truncateMiddle.ts</strong><dd><code>Add string truncation utility for digest display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

utils/truncateMiddle.ts

<li>Added new utility to truncate strings in the middle for digest display


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/122/files#diff-00611d27460aba55c4f7e582ab838fffde8aa80cf7893a0e2e6805ce20c90cd6">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>