### PR TITLE
SHARD-2431: point to docs for update url instead of outdated repo

### DIFF
--- a/components/molecules/InformationPopupsDisplay.tsx
+++ b/components/molecules/InformationPopupsDisplay.tsx
@@ -10,7 +10,7 @@ const newGuiVersionAvailableKey = 'newGuiVersionAvailable'
 const newValidatorVersionAvailableKey = 'newValidatorVersionAvailable'
 
 const VERSION_UPDATE_REPOSITORY_URL =
-  process.env.VERSION_UPDATE_REPOSITORY_URL ?? 'https://github.com/shardeum/validator-dashboard'
+  process.env.VERSION_UPDATE_REPOSITORY_URL ?? 'https://docs.shardeum.org/docs/node/run/validator/setup/self-host#update'
 
 export const InformationPopupsDisplay = () => {
   const { addNotification } = useNotificationsStore((state: any) => ({


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Update default URL for version update instructions

- Point to documentation instead of outdated repository

- Improve user guidance for validator updates


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InformationPopupsDisplay.tsx</strong><dd><code>Update version update URL to point to documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/molecules/InformationPopupsDisplay.tsx

<li>Changed default <code>VERSION_UPDATE_REPOSITORY_URL</code> to point to <br>documentation<br> <li> Replaced outdated GitHub repo link with docs link for validator <br>updates


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/123/files#diff-b76b1d142508d73386a9e3eb66c061473e6e64b8529487847245e7a667fbd68c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>