### PR TITLE
SHARD-2495: Default min stake to -.- when failed to fetch

### DIFF
--- a/components/molecules/AddStakeModal.tsx
+++ b/components/molecules/AddStakeModal.tsx
@@ -31,7 +31,7 @@ export const AddStakeModal = () => {
   const stakeInputRef = useRef<HTMLInputElement>(null)
   const [stakedAmount, setStakedAmount] = useState(0)
   const minimumStakeRequirement = useMemo(() => {
-    return Math.max(parseFloat(nodeStatus?.stakeRequirement || '10') - parseFloat(nodeStatus?.lockedStake || '0'), 0)
+    return Math.max(parseFloat(nodeStatus?.stakeRequirement || '—.—') - parseFloat(nodeStatus?.lockedStake || '0'), 0)
   }, [nodeStatus?.stakeRequirement, nodeStatus?.lockedStake])
 
   // Use wallet balance hook for fetching balance
@@ -135,7 +135,7 @@ export const AddStakeModal = () => {
             <div className="flex justify-between">
               <div className={'text-xs ' + (stakedAmount < minimumStakeRequirement ? 'text-dangerFg' : 'text-black')}>
                 <span>Minimum stake requirement: </span>
-                <span className="font-semibold">{nodeStatus?.stakeRequirement || '10'} SHM</span>
+                <span className="font-semibold">{nodeStatus?.stakeRequirement || '—.—'} SHM</span>
               </div>
               {(balanceData || data) && (
                 <div className="text-xs">

--- a/components/molecules/StakeDisplay.tsx
+++ b/components/molecules/StakeDisplay.tsx
@@ -101,7 +101,7 @@ export const StakeDisplay = () => {
             <span className="text-lg md:text-xl font-semibold">{stakeForConnectedAddressOrNode.toFixed(2)} SHM</span>
             <div className="flex gap-x-1 items-center">
               <span className="text-xs font-light">Min. requirement: </span>
-              <span className="text-sm">{nodeStatus?.stakeRequirement || '10'} SHM</span>
+              <span className="text-sm">{nodeStatus?.stakeRequirement || '—.—'} SHM</span>
             </div>
           </div>
           <hr className="my-1 mx-3" />
@@ -214,9 +214,7 @@ export const StakeDisplay = () => {
         )}
         {isConnectedToNonNominee && (
           <div className={`flex gap-x-2 items-center px-4 py-2 bg-dangerBg border-gray-200 border-t`}>
-            <span className="bodyFg font-light text-xs ">
-              This wallet is not the current staker of this node.
-            </span>
+            <span className="bodyFg font-light text-xs ">This wallet is not the current staker of this node.</span>
           </div>
         )}
       </>

--- a/components/onboarding/StakeStep.tsx
+++ b/components/onboarding/StakeStep.tsx
@@ -25,7 +25,7 @@ export const StakeStep = ({ stepNumber }: StakeStepProps) => {
   }, [nodeStatus?.state])
 
   const minimumStakeRequirement = useMemo(() => {
-    return Math.max(parseFloat(nodeStatus?.stakeRequirement || '10') - parseFloat(nodeStatus?.lockedStake || '0'), 0)
+    return Math.max(parseFloat(nodeStatus?.stakeRequirement || '—.—') - parseFloat(nodeStatus?.lockedStake || '0'), 0)
   }, [nodeStatus?.stakeRequirement, nodeStatus?.lockedStake])
 
   const {
@@ -126,7 +126,7 @@ export const StakeStep = ({ stepNumber }: StakeStepProps) => {
                 <div className="flex justify-between">
                   <div className={`text-xs ${stakedAmount < minimumStakeRequirement ? 'text-dangerFg' : ''}`}>
                     <span>Minimum stake requirement: </span>
-                    <span className="font-semibold">{nodeStatus?.stakeRequirement || '10'} SHM</span>
+                    <span className="font-semibold">{nodeStatus?.stakeRequirement || '—.—'} SHM</span>
                   </div>
                 </div>
               </div>

--- a/pages/onboarding/index.tsx
+++ b/pages/onboarding/index.tsx
@@ -119,7 +119,7 @@ const Onboarding = () => {
   const { disconnect } = useDisconnect()
   const { nodeStatus, isLoading, startNode } = useNodeStatus()
   const minimumStakeRequirement = useMemo(() => {
-    return Math.max(parseFloat(nodeStatus?.stakeRequirement || '10') - parseFloat(nodeStatus?.lockedStake || '0'), 0)
+    return Math.max(parseFloat(nodeStatus?.stakeRequirement || '—.—') - parseFloat(nodeStatus?.lockedStake || '0'), 0)
   }, [nodeStatus?.stakeRequirement, nodeStatus?.lockedStake])
 
   const {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Default minimum stake to '—.—' when fetch fails

- Updated UI to display '—.—' instead of '10' SHM fallback

- Applied changes across AddStakeModal, StakeDisplay, StakeStep, and onboarding

- Minor formatting fix in StakeDisplay warning message


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AddStakeModal.tsx</strong><dd><code>Use '—.—' as fallback for minimum stake in AddStakeModal</code>&nbsp; </dd></summary>
<hr>

components/molecules/AddStakeModal.tsx

<li>Changed fallback minimum stake from '10' to '—.—' in calculations and <br>display<br> <li> Updated UI to show '—.—' SHM if stake requirement is unavailable


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/125/files#diff-84bca6181ab22d64476705583a9f08c1471eed5bb696b7cc2310afb28b49f3ff">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StakeDisplay.tsx</strong><dd><code>Display '—.—' as fallback for minimum stake in StakeDisplay</code></dd></summary>
<hr>

components/molecules/StakeDisplay.tsx

<li>Changed fallback minimum stake display from '10' to '—.—' SHM<br> <li> Minor formatting fix in non-nominee warning message


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/125/files#diff-43720225c208b87686fb4dc52e5e595716722ddb5ccff33899f0f81d823ebe4f">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StakeStep.tsx</strong><dd><code>Use '—.—' as fallback for minimum stake in StakeStep</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

components/onboarding/StakeStep.tsx

<li>Changed fallback minimum stake from '10' to '—.—' in calculations and <br>display<br> <li> Updated UI to show '—.—' SHM if stake requirement is unavailable


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/125/files#diff-a9ea4c3e45877fb275573ae5ca359e796170ca03dcfbf994c8c98203630a268e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Use '—.—' as fallback for minimum stake in onboarding page</code></dd></summary>
<hr>

pages/onboarding/index.tsx

- Changed fallback minimum stake from '10' to '—.—' in calculations


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/125/files#diff-908d1b7af17415a2f8e0a58cfe62350737e85057197de66feea77c6b3ee13a68">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>