### PR TITLE
Fixed Error Handling for Unstaking

### DIFF
--- a/api/types/node-types.ts
+++ b/api/types/node-types.ts
@@ -13,6 +13,16 @@ export type NodeStatus = {
   currentRewards: string
   lastPayout: string
   lifetimeEarnings: string
+  stakeState?: {
+    reason: string
+    remainingTime: number
+    unlocked: boolean
+  }
+  stakeable?: {
+    reason: string
+    remainingTime: number
+    restakeAllowed: boolean
+  }
   nodeInfo: {
     externalIp: string
     externalPort: number

--- a/components/RemoveStakeButton.tsx
+++ b/components/RemoveStakeButton.tsx
@@ -11,11 +11,12 @@ import { Address } from 'wagmi'
 import { ExternalProvider } from '@ethersproject/providers'
 import { NodeStatus } from '../model/node-status'
 import { useSettings } from '../hooks/useSettings'
+import { useNodeStatus } from '../hooks/useNodeStatus'
 
 export default function RemoveStakeButton({
   nominee,
   force = false,
-  nodeStatus,
+  nodeStatus: nodeState,
 }: {
   nominee: string
   force?: boolean
@@ -25,6 +26,7 @@ export default function RemoveStakeButton({
   const { writeUnstakeLog } = useTXLogs()
   const { openModal } = useContext(ConfirmModalContext)
   const { settings, mutate: mutateSettings } = useSettings()
+  const { nodeStatus } = useNodeStatus()
   const ethereum = window.ethereum
 
   const createUnstakeLog = (data: unknown, params: { data: unknown }, hash: string, sender: string) => {
@@ -88,6 +90,8 @@ export default function RemoveStakeButton({
         (isEthersError(error) && error.code === 'ACTION_REJECTED')
       ) {
         errorMessage = 'Transaction rejected by user'
+      } else if (isEthersError(error) && error.code === 'CALL_EXCEPTION') {
+        errorMessage = 'Transaction failed: Your node may still be in the deregistration process. Please wait for deregistration to complete before unstaking.'
       }
       showErrorDetails(errorMessage)
     }
@@ -139,6 +143,17 @@ export default function RemoveStakeButton({
 
   async function removeStake() {
     setLoading(true)
+
+    // Check if deregistration is in progress (unless forcing)
+    if (!force && nodeStatus?.stakeState && !nodeStatus.stakeState.unlocked) {
+      const remainingMinutes = Math.ceil(nodeStatus.stakeState.remainingTime / 60000)
+      showErrorDetails(
+        `Cannot unstake: ${nodeStatus.stakeState.reason} Please wait ${remainingMinutes} more minutes before attempting to unstake.`
+      )
+      setLoading(false)
+      return
+    }
+
     await connectWallet()
   }
 
@@ -182,10 +197,10 @@ export default function RemoveStakeButton({
               isLoading={isLoading}
               disabled={
                 !force &&
-                (nodeStatus === 'waiting-for-network' ||
-                  nodeStatus === 'standby' ||
-                  nodeStatus === 'syncing' ||
-                  nodeStatus === 'active')
+                (nodeState === 'waiting-for-network' ||
+                  nodeState === 'standby' ||
+                  nodeState === 'syncing' ||
+                  nodeState === 'active')
               }
               onClick={() => handleRemoveStake()}
             >

--- a/components/RemoveStakeButton.tsx
+++ b/components/RemoveStakeButton.tsx
@@ -12,6 +12,7 @@ import { ExternalProvider } from '@ethersproject/providers'
 import { NodeStatus } from '../model/node-status'
 import { useSettings } from '../hooks/useSettings'
 import { useNodeStatus } from '../hooks/useNodeStatus'
+import { validateUnstakeEligibility } from '../utils/unstakeValidation'
 
 export default function RemoveStakeButton({
   nominee,
@@ -144,12 +145,9 @@ export default function RemoveStakeButton({
   async function removeStake() {
     setLoading(true)
 
-    // Check if deregistration is in progress (unless forcing)
-    if (!force && nodeStatus?.stakeState && !nodeStatus.stakeState.unlocked) {
-      const remainingMinutes = Math.ceil(nodeStatus.stakeState.remainingTime / 60000)
-      showErrorDetails(
-        `Cannot unstake: ${nodeStatus.stakeState.reason} Please wait ${remainingMinutes} more minutes before attempting to unstake.`
-      )
+    const validation = validateUnstakeEligibility(force, nodeStatus)
+    if (!validation.canUnstake) {
+      showErrorDetails(validation.errorMessage!)
       setLoading(false)
       return
     }

--- a/hooks/useNotificationsStore.ts
+++ b/hooks/useNotificationsStore.ts
@@ -26,7 +26,9 @@ const notificationsKey = 'pendingNotifications'
 
 const persistNotifications = (notifications: NotificationInstance[]) => {
   try {
-    window.localStorage.setItem(notificationsKey, JSON.stringify(notifications))
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(notificationsKey, JSON.stringify(notifications))
+    }
   } catch (error) {
     console.log(error)
   }
@@ -34,10 +36,14 @@ const persistNotifications = (notifications: NotificationInstance[]) => {
 
 const fetchPreviousNotifications = () => {
   try {
-    const notificationsItem = window.localStorage.getItem(notificationsKey)
-    return notificationsItem ? JSON.parse(notificationsItem) : []
+    if (typeof window !== 'undefined') {
+      const notificationsItem = window.localStorage.getItem(notificationsKey)
+      return notificationsItem ? JSON.parse(notificationsItem) : []
+    }
+    return []
   } catch (error) {
     console.log(error)
+    return []
   }
 }
 

--- a/hooks/useUnstake.ts
+++ b/hooks/useUnstake.ts
@@ -10,6 +10,7 @@ import { showErrorMessage, showSuccessMessage } from './useToastStore'
 import { Constants } from '../utils/constants'
 import { useLocalStorage } from './useLocalStorage'
 import { useNodeStatus } from './useNodeStatus'
+import { validateUnstakeEligibility } from '../utils/unstakeValidation'
 
 type useStakeProps = {
   nominator: string
@@ -121,12 +122,9 @@ export const useUnstake = ({ nominator, nominee, force }: useStakeProps) => {
   const handleRemoveStake = async () => {
     setLoading(true)
 
-    // Check if deregistration is in progress (unless forcing)
-    if (!force && nodeStatus?.stakeState && !nodeStatus.stakeState.unlocked) {
-      const remainingMinutes = Math.ceil(nodeStatus.stakeState.remainingTime / 60000)
-      showErrorMessage(
-        `Cannot unstake: ${nodeStatus.stakeState.reason} Please wait ${remainingMinutes} more minutes before attempting to unstake.`
-      )
+    const validation = validateUnstakeEligibility(force, nodeStatus)
+    if (!validation.canUnstake) {
+      showErrorMessage(validation.errorMessage!)
       setLoading(false)
       return false
     }

--- a/hooks/useUnstake.ts
+++ b/hooks/useUnstake.ts
@@ -9,6 +9,7 @@ import { Address } from 'wagmi'
 import { showErrorMessage, showSuccessMessage } from './useToastStore'
 import { Constants } from '../utils/constants'
 import { useLocalStorage } from './useLocalStorage'
+import { useNodeStatus } from './useNodeStatus'
 
 type useStakeProps = {
   nominator: string
@@ -19,6 +20,7 @@ type useStakeProps = {
 export const useUnstake = ({ nominator, nominee, force }: useStakeProps) => {
   const [, setLastUnstake] = useLocalStorage(Constants.UNSTAKE_COOLDOWN_KEY, '0')
   const { writeUnstakeLog } = useTXLogs()
+  const { nodeStatus } = useNodeStatus()
   const ethereum = window.ethereum
 
   const createUnstakeLog = (data: unknown, params: { data: unknown }, hash: string, sender: string) => {
@@ -84,6 +86,8 @@ export const useUnstake = ({ nominator, nominee, force }: useStakeProps) => {
         (isEthersError(error) && error.code === 'ACTION_REJECTED')
       ) {
         errorMessage = 'Transaction rejected by user'
+      } else if (isEthersError(error) && error.code === 'CALL_EXCEPTION') {
+        errorMessage = 'Transaction failed: Your node may still be in the deregistration process. Please wait for deregistration to complete before unstaking.'
       }
       showErrorMessage(errorMessage)
     }
@@ -116,9 +120,18 @@ export const useUnstake = ({ nominator, nominee, force }: useStakeProps) => {
 
   const handleRemoveStake = async () => {
     setLoading(true)
-    // await new Promise(r => setTimeout(r, 3000));
+
+    // Check if deregistration is in progress (unless forcing)
+    if (!force && nodeStatus?.stakeState && !nodeStatus.stakeState.unlocked) {
+      const remainingMinutes = Math.ceil(nodeStatus.stakeState.remainingTime / 60000)
+      showErrorMessage(
+        `Cannot unstake: ${nodeStatus.stakeState.reason} Please wait ${remainingMinutes} more minutes before attempting to unstake.`
+      )
+      setLoading(false)
+      return false
+    }
+
     const wasUnstakeSuccessful = await sendTransaction(nominator, nominee, force)
-    // const wasUnstakeSuccessful = true;
     setLoading(false)
     return wasUnstakeSuccessful
   }

--- a/utils/unstakeValidation.ts
+++ b/utils/unstakeValidation.ts
@@ -1,0 +1,23 @@
+import { NodeStatus } from '../model/node-status'
+
+export interface UnstakeValidationResult {
+  canUnstake: boolean
+  errorMessage?: string
+}
+
+export const validateUnstakeEligibility = (
+  force: boolean,
+  nodeStatus: NodeStatus | null | undefined
+): UnstakeValidationResult => {
+  if (!force && nodeStatus?.stakeState && !nodeStatus.stakeState.unlocked) {
+    const remainingMinutes = Math.ceil(nodeStatus.stakeState.remainingTime / 60000)
+    return {
+      canUnstake: false,
+      errorMessage: `Cannot unstake: ${nodeStatus.stakeState.reason} Please wait ${remainingMinutes} more minutes before attempting to unstake.`
+    }
+  }
+
+  return {
+    canUnstake: true
+  }
+}


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improved error handling for unstaking during deregistration.

- Added checks to prevent unstaking if node is not unlocked.

- Enhanced user feedback with specific error messages.

- Extended NodeStatus type with stakeState and stakeable fields.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node-types.ts</strong><dd><code>Extend NodeStatus type with stakeState and stakeable fields</code></dd></summary>
<hr>

api/types/node-types.ts

<li>Added optional stakeState and stakeable fields to NodeStatus type.<br> <li> Extended NodeStatus to support more granular staking state <br>information.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/129/files#diff-31cc923ffefaf07b5f4f954bc22534feb2eebf86807af0647c59a26031137ce0">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RemoveStakeButton.tsx</strong><dd><code>Add unstake checks and improved error handling in RemoveStakeButton</code></dd></summary>
<hr>

components/RemoveStakeButton.tsx

<li>Integrated nodeStatus from useNodeStatus hook.<br> <li> Added check to prevent unstaking if node is not unlocked.<br> <li> Improved error message for transaction call exceptions.<br> <li> Updated button disabling logic to use nodeState.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/129/files#diff-779e07e8b7cc8599ac7e7fd4761677bf161de9a8af4d1f91b8a76c5f45ed5f20">+21/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useUnstake.ts</strong><dd><code>Add unstake checks and improved error handling in useUnstake</code></dd></summary>
<hr>

hooks/useUnstake.ts

<li>Integrated nodeStatus from useNodeStatus hook.<br> <li> Added check to prevent unstaking if node is not unlocked.<br> <li> Enhanced error handling for transaction call exceptions.<br> <li> Improved user feedback on unstaking restrictions.


</details>


  </td>
  <td><a href="https://github.com/shardeum/shardeum-validator-gui/pull/129/files#diff-402be3e9a29e3347cb24406c9b5470bf8d98804606f23f9e417f69a41fcc6ab4">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>